### PR TITLE
Fix template override example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ themes/mytheme/templates/nathancox/EmbedField/Model/EmbedObject_video.ss:
 ```html
 
 	<div class='flex-video self-sizing' style='padding-bottom:$AspectRatioHeight;'>
-		$HTML
+		$EmbedHTML
 	</div>
 
 ```


### PR DESCRIPTION
$HTML is empty, $EmbedHTML is the correct variable.