### PR TITLE
Patch: support for embed/embed 4.x and  Silverstripe Framework 4.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
 		"issues": "https://github.com/nathancox/silverstripe-embedfield/issues"
 	},
 	"require": {
+		"embed/embed": "^4",
 		"silverstripe/framework": "~4.0"
 	},
 	"extra": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	},
 	"require": {
 		"embed/embed": "^4",
-		"silverstripe/framework": "~4.0"
+		"silverstripe/framework": "^4.11.0"
 	},
 	"extra": {
 		"screenshots": [

--- a/src/Model/EmbedObject.php
+++ b/src/Model/EmbedObject.php
@@ -49,8 +49,8 @@ class EmbedObject extends DataObject {
 		if ($this->SourceURL) {
 			$sourceURL = $this->SourceURL;
 		}
-        $embed = new Embed();
-        $info = $embed->get($sourceURL);
+		$embed = new Embed();
+		$info = $embed->get($sourceURL);
 		//Oembed::get_oembed_from_url($sourceURL);
 
 		$this->updateFromObject($info);
@@ -67,7 +67,7 @@ class EmbedObject extends DataObject {
 
 			// Several properties no longer supported. These can potentially be re-introduced
 			// by writing custom detectors: https://github.com/oscarotero/Embed#detectors
-			
+		
 			//$this->Type = $info->type;
 
 			//$this->Width = $info->getWidth();

--- a/src/Model/EmbedObject.php
+++ b/src/Model/EmbedObject.php
@@ -49,38 +49,46 @@ class EmbedObject extends DataObject {
 		if ($this->SourceURL) {
 			$sourceURL = $this->SourceURL;
 		}
-		$info = Embed::create($sourceURL);
+        $embed = new Embed();
+        $info = $embed->get($sourceURL);
 		//Oembed::get_oembed_from_url($sourceURL);
 
 		$this->updateFromObject($info);
 	}
 
 	function updateFromObject($info) {
-		if ($info && $info->getWidth()) {
+		// Previously this line checked width. Unsure if this was just to
+		// check if object was populated, or if width was of specific importence
+		// Assuming the former and checking URL instead
+		if ($info && $info->url) {
 			$this->sourceExists = true;
+
+			$this->Title = $info->title;
+
+			// Several properties no longer supported. These can potentially be re-introduced
+			// by writing custom detectors: https://github.com/oscarotero/Embed#detectors
 			
-			$this->Title = $info->getTitle();
-			$this->Type = $info->type;
+			//$this->Type = $info->type;
 
-			$this->Width = $info->getWidth();
-			$this->Height = $info->getHeight();
+			//$this->Width = $info->getWidth();
+			//$this->Height = $info->getHeight();
 
-			$this->ThumbnailURL = $info->getImage();
-			$this->ThumbnailWidth = $info->thumbnail_width;
-			$this->ThumbnailHeight = $info->thumbnail_height;
+			//$this->ThumbnailURL = $info->getImage();
+			//$this->ThumbnailWidth = $info->thumbnail_width;
+			//$this->ThumbnailHeight = $info->thumbnail_height;
 
-			$this->ProviderURL = $info->provider_url;
-			$this->ProviderName = $info->provider_name;
+			$this->ProviderURL = (string) $info->providerUrl;
+			$this->ProviderName = $info->providerName;
 
 
-			$this->AuthorURL = $info->author_url;
-			$this->AuthorName = $info->author_name;
+			$this->AuthorURL = (string) $info->authorUrl;
+			$this->AuthorName = $info->authorName;
 
-			$embed = $info->getCode();
-			$this->EmbedHTML = $embed;
-			$this->URL = $info->url;
-			$this->Origin = $info->origin;
-			$this->WebPage = $info->web_page;
+			$embed = $info->code;
+			$this->EmbedHTML = (string) $embed;
+			$this->URL = (string) $info->url;
+			//$this->Origin = $info->origin;
+			//$this->WebPage = $info->web_page;
 
 		} else {
 			$this->sourceExists = false;


### PR DESCRIPTION
Addresses #13 

This is a partial fix. It suppresses errors by swapping old methods for new properties, but since not all the old methods are available out of the box it leaves the EmbedObject missing some data it previously had.

The rest may be resolvable by writing custom detectors: https://github.com/oscarotero/Embed#detectors. But that is additional work yet to be done.